### PR TITLE
updated github library to use pygithub instead of python-github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 annotated-types==0.6.0
 anyio==4.3.0
 certifi==2024.2.2
+cffi==1.16.0
 charset-normalizer==3.3.2
+cryptography==42.0.7
+Deprecated==1.2.14
 distro==1.9.0
 exceptiongroup==1.2.1
 h11==0.14.0
@@ -16,9 +19,12 @@ langsmith==0.1.54
 openai==1.25.2
 orjson==3.10.3
 packaging==23.2
+pycparser==2.22
 pydantic==2.7.1
 pydantic_core==2.18.2
-python-github==0.1.0.dev0
+PyGithub==2.3.0
+PyJWT==2.8.0
+PyNaCl==1.5.0
 PyYAML==6.0.1
 regex==2024.4.28
 requests==2.31.0
@@ -28,3 +34,4 @@ tiktoken==0.6.0
 tqdm==4.66.4
 typing_extensions==4.11.0
 urllib3==2.2.1
+wrapt==1.16.0


### PR DESCRIPTION
Updated libraries to use PyGitHub instead of python-github. The model being used to generate READMEs is OpenAIs gpt-3.5-turbo-1235.